### PR TITLE
Correct path for macos CI, use ls to find binary, update oldest ubuntu CI runner image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,7 +184,7 @@ jobs:
       run: |
           wget https://sdk.lunarg.com/sdk/download/latest/mac/vulkan-sdk.zip -O vulkan-sdk.zip
           unzip vulkan-sdk.zip
-          binary=`find ./* -path *vulkansdk-macOS-*.app/Contents/MacOS/vulkansdk-macOS-*`
+          binary=`ls *vulkansdk-macOS-*.app/Contents/MacOS/*`
           sudo ${binary} --root ~/vulkan --accept-licenses --default-answer --confirm-command install
           ls ~/vulkan
           cd ~/vulkan/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
           path: docs/latex/SimpleFastOpenAtomicVisualiser.pdf
 
   linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,7 +184,7 @@ jobs:
       run: |
           wget https://sdk.lunarg.com/sdk/download/latest/mac/vulkan-sdk.zip -O vulkan-sdk.zip
           unzip vulkan-sdk.zip
-          binary=`find ./* -path *MacOS/InstallVulkan*`
+          binary=`find ./* -path *vulkansdk-macOS-*.app/Contents/MacOS/vulkansdk-macOS-*`
           sudo ${binary} --root ~/vulkan --accept-licenses --default-answer --confirm-command install
           ls ~/vulkan
           cd ~/vulkan/


### PR DESCRIPTION
- New install path https://vulkan.lunarg.com/doc/sdk/1.4.313.0/mac/getting_started.html
- Oldest github image updates https://github.com/actions/runner-images